### PR TITLE
Enforce setVariable broadcast parameter

### DIFF
--- a/addons/main/functions/fn_editRespawnTicketsModule.sqf
+++ b/addons/main/functions/fn_editRespawnTicketsModule.sqf
@@ -15,7 +15,7 @@ private _display = uiNamespace getVariable QGVAR(RscRespawnTicketsDisplay);
 private _bluforTicketCount = missionNamespace getVariable QGVAR(BluforTicketCount);
 private _opforTicketCount = missionNamespace getVariable QGVAR(OpforTicketCount);
 private _indepTicketCount = missionNamespace getVariable QGVAR(IndepTicketCount);
-private _civilianTicketCount = missionNamespace getVariable QGVAR(CivilianforTicketCount);
+private _civilianTicketCount = missionNamespace getVariable QGVAR(CivilianTicketCount);
 
 {
 	_x params ["_variableName", "_controlIDC"];
@@ -34,7 +34,7 @@ private _civilianTicketCount = missionNamespace getVariable QGVAR(CivilianforTic
 	[QGVAR(BluforTicketCount), IDC_RESPAWN_TICKETS_BLUFORINPUT],
 	[QGVAR(OpforTicketCount), IDC_RESPAWN_TICKETS_OPFORINPUT],
 	[QGVAR(IndepTicketCount), IDC_RESPAWN_TICKETS_INDEPINPUT],
-	[QGVAR(CivilianforTicketCount), IDC_RESPAWN_TICKETS_CIVINPUT]
+	[QGVAR(CivilianTicketCount), IDC_RESPAWN_TICKETS_CIVINPUT]
 ];
 
 private _ctrlButtonCancel = _display displayCtrl IDC_CANCEL;
@@ -62,7 +62,7 @@ _ctrlButtonOK ctrlAddEventHandler ["ButtonClick", {
 		[QGVAR(BluforTicketCount), IDC_RESPAWN_TICKETS_BLUFORINPUT],
 		[QGVAR(OpforTicketCount), IDC_RESPAWN_TICKETS_OPFORINPUT],
 		[QGVAR(IndepTicketCount), IDC_RESPAWN_TICKETS_INDEPINPUT],
-		[QGVAR(CivilianforTicketCount), IDC_RESPAWN_TICKETS_CIVINPUT]
+		[QGVAR(CivilianTicketCount), IDC_RESPAWN_TICKETS_CIVINPUT]
 	];
 
 	_display closeDisplay IDC_OK;

--- a/addons/main/functions/fn_editRespawnTicketsModule.sqf
+++ b/addons/main/functions/fn_editRespawnTicketsModule.sqf
@@ -56,7 +56,7 @@ _ctrlButtonOK ctrlAddEventHandler ["ButtonClick", {
 		private _input = _display displayCtrl _controlIDC;
 
 		if (!isNil QUOTE(_ticketCount)) then {
-			missionNamespace setVariable [_variableName, parseNumber ctrlText _input];
+			missionNamespace setVariable [_variableName, parseNumber ctrlText _input, true];
 		};
 	} forEach [
 		[QGVAR(BluforTicketCount), IDC_RESPAWN_TICKETS_BLUFORINPUT],

--- a/addons/main/functions/fn_zeusRegister.sqf
+++ b/addons/main/functions/fn_zeusRegister.sqf
@@ -32,13 +32,13 @@ private _wait = [player] spawn
 		private _bluforTicketCount = missionNamespace getVariable QGVAR(BluforTicketCount);
 		private _opforTicketCount = missionNamespace getVariable QGVAR(OpforTicketCount);
 		private _indepTicketCount = missionNamespace getVariable QGVAR(IndepTicketCount);
-		private _civilianTicketCount = missionNamespace getVariable QGVAR(CivilianforTicketCount);
+		private _civilianTicketCount = missionNamespace getVariable QGVAR(CivilianTicketCount);
 
 		private _respawnSystemUsed = (
 			!isNil QUOTE(_bluforTicketCount)
 			|| !isNil QUOTE(OpforTicketCount)
 			|| !isNil QUOTE(IndepTicketCount)
-			|| !isNil QUOTE(CivilianforTicketCount)
+			|| !isNil QUOTE(CivilianTicketCount)
 		);
 		_respawnSystemUsed;
 	};

--- a/addons/main/functions/fn_zeusRegister.sqf
+++ b/addons/main/functions/fn_zeusRegister.sqf
@@ -36,9 +36,9 @@ private _wait = [player] spawn
 
 		private _respawnSystemUsed = (
 			!isNil QUOTE(_bluforTicketCount)
-			|| !isNil QUOTE(OpforTicketCount)
-			|| !isNil QUOTE(IndepTicketCount)
-			|| !isNil QUOTE(CivilianTicketCount)
+			|| !isNil QUOTE(_opforTicketCount)
+			|| !isNil QUOTE(_indepTicketCount)
+			|| !isNil QUOTE(_civilianTicketCount)
 		);
 		_respawnSystemUsed;
 	};

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 1
-#define MINOR 1
+#define MINOR 2
 #define PATCHLVL 0
 #define BUILD 0

--- a/docs/editRespawnTicketsModule/readme.md
+++ b/docs/editRespawnTicketsModule/readme.md
@@ -44,19 +44,19 @@ missionNamespace setVariable ["timberZA_main_BluforTicketCount", 100];
         switch (side _unit) do {
             case west : {
                 private _bluforTicketCount = missionNamespace getVariable ["timberZA_main_BluforTicketCount", 0];
-                missionNamespace setVariable ["timberZA_main_BluforTicketCount", _bluforTicketCount - 1];
+                missionNamespace setVariable ["timberZA_main_BluforTicketCount", _bluforTicketCount - 1, true];
             };
             case east : {
                 private _opforTicketCount = missionNamespace getVariable ["timberZA_main_OpforTicketCount", 0];
-                missionNamespace setVariable ["timberZA_main_OpforTicketCount", _opforTicketCount - 1];
+                missionNamespace setVariable ["timberZA_main_OpforTicketCount", _opforTicketCount - 1, true];
             };
             case independent : {
                 private _indepTicketCount = missionNamespace getVariable ["timberZA_main_IndepTicketCount", 0];
-                missionNamespace setVariable ["timberZA_main_IndepTicketCount", _indepTicketCount - 1];
+                missionNamespace setVariable ["timberZA_main_IndepTicketCount", _indepTicketCount - 1, true];
             };
             case civilian : {
                 private _civilianTicketCount = missionNamespace getVariable ["timberZA_main_CivilianTicketCount", 0];
-                missionNamespace setVariable ["timberZA_main_CivilianTicketCount", _civilianTicketCount - 1];
+                missionNamespace setVariable ["timberZA_main_CivilianTicketCount", _civilianTicketCount - 1, true];
             };
         };
     }];

--- a/docs/editRespawnTicketsModule/readme.md
+++ b/docs/editRespawnTicketsModule/readme.md
@@ -11,7 +11,7 @@ You have 4 field, one per side. Each field corresponds to one variable inside th
 - Blufor = `timberZA_main_BluforTicketCount`
 - Opfor = `timberZA_main_OpforTicketCount`
 - Independent = `timberZA_main_IndepTicketCount`
-- Civilian = `timberZA_main_CivilianforTicketCount`
+- Civilian = `timberZA_main_CivilianTicketCount`
 
 **Inputs will be disabled if the corresponding missionNamespace variables aren't defined in the mission files. If none of the variables are defined, the module will not be available in the zeus interface.**
 
@@ -55,8 +55,8 @@ missionNamespace setVariable ["timberZA_main_BluforTicketCount", 100];
                 missionNamespace setVariable ["timberZA_main_IndepTicketCount", _indepTicketCount - 1];
             };
             case civilian : {
-                private _civilianTicketCount = missionNamespace getVariable ["timberZA_main_CivilianforTicketCount", 0];
-                missionNamespace setVariable ["timberZA_main_CivilianforTicketCount", _civilianTicketCount - 1];
+                private _civilianTicketCount = missionNamespace getVariable ["timberZA_main_CivilianTicketCount", 0];
+                missionNamespace setVariable ["timberZA_main_CivilianTicketCount", _civilianTicketCount - 1];
             };
         };
     }];


### PR DESCRIPTION
In order to sync the ticket values on all machines, we need to enforce the third parameter of `setVariable`.